### PR TITLE
Fix package discovery after removing setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dependencies = [
     "psutil"
 ]
 
+[tool.setuptools.packages.find]
+include = ["waveome*"]
+
 [project.urls]
 Homepage = "https://github.com/omicsEye/waveome"
 "Bug Tracker" = "https://github.com/omicsEye/waveome/issues"


### PR DESCRIPTION
setup.py explicitly set packages=["waveome"], preventing setuptools from auto-discovering unrelated top-level dirs (figures, multioutput, kernel_learning). Add explicit find directive to pyproject.toml.